### PR TITLE
update radiotap git URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "radiotap"]
 	path = radiotap
-	url = http://git.sipsolutions.net/radiotap.git
+	url = https://git.sipsolutions.net/radiotap.git


### PR DESCRIPTION
Seems they use https now, and git clone on http fails.