### PR TITLE
Drop packets with malformed radiotap headers

### DIFF
--- a/linux/raw_parser.c
+++ b/linux/raw_parser.c
@@ -243,8 +243,10 @@ int uwifi_parse_raw(unsigned char* buf, size_t len, struct uwifi_packet* p, int 
 		return -1;
 	}
 
-	if (ret <= 0) /* 0: Bad FCS, allow packet but stop parsing */
+	if (ret == 0) /* 0: Bad FCS, allow packet but stop parsing */
 		return ret;
+	else if (ret < 0) /* Malformed header, don't allow packet */
+		return -1;
 
 	if ((size_t)ret >= len) {
 		LOG_DBG("impossible len");


### PR DESCRIPTION
This should fix https://github.com/br101/horst/issues/102

(See also https://github.com/br101/horst/pull/103, which fixes the same issue but on the `stable` branch of `br101/horst`)